### PR TITLE
Support offset modifier on vectors

### DIFF
--- a/promformat/formatter.py
+++ b/promformat/formatter.py
@@ -255,7 +255,7 @@ class BuildAstVisitor(PromQLParserVisitor):
         print("visitVector")
 
     def visitOffset(self, ctx: PromQLParser.OffsetContext):
-        selector = self.visit(ctx.instantSelector())
+        selector = self.visit(ctx.instantSelector() or ctx.matrixSelector())
         return OffsetNode(
             ctx,
             instant_selector=selector,

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,14 @@ from setuptools import setup, find_packages
 
 setup(
     name="promformat",
-    version="0.0.3",
+    version="0.0.4",
     packages=find_packages(),
-    install_requires=[
-        "antlr4-python3-runtime>=4.10"
-    ],
+    install_requires=["antlr4-python3-runtime>=4.10"],
     tests_require=["pytest"],
     setup_requires=["flake8", "black"],
-    entry_points = {
-        'console_scripts': [
-            'promformat = promformat.__main__:main',
+    entry_points={
+        "console_scripts": [
+            "promformat = promformat.__main__:main",
         ],
     },
 )

--- a/tests/resources/test-promql.yaml
+++ b/tests/resources/test-promql.yaml
@@ -643,6 +643,11 @@ groups:
                 query: 'pg_bloat_table_bloat_pct > 80 and on (relname) (pg_bloat_table_real_size > 200000000)'
                 severity: warning
                 for: 1h
+              - name: Postgresql basebackup not started
+                description: The service has not started backing up
+                query: 'last_over_time ( basebackup { } [12h] offset 5m) > 0 unless on (fire) last_over_time ( progress{} [12h]) > 0'
+                severity: warning
+                for: 1h
 
       - name: SQL Server
         exporters:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,10 +1,10 @@
 import pkg_resources
 import yaml
-
+import pytest
 from promformat.__main__ import format_query
 
 
-def test_formatter():
+def get_rules():
     rule_path = pkg_resources.resource_filename("tests.resources", "test-promql.yaml")
     with open(rule_path) as f:
         data = yaml.safe_load(f)
@@ -14,5 +14,21 @@ def test_formatter():
                     rules = exporter.get("rules")
                     if rules:
                         for rule in rules:
-                            res = format_query(rule["query"])
-                            assert res
+                            yield dict(
+                                group=group.get("name", "unnamed group"),
+                                service=service.get("name", "unnamed service"),
+                                exporter=exporter.get("name", "unnamed exporter"),
+                                rule=rule.get("name", "unnamed rule"),
+                                query=rule["query"],
+                            )
+
+
+@pytest.mark.parametrize(
+    ["query"],
+    [
+        pytest.param(rule["query"], id="{service}/{exporter}/{rule}".format(**rule))
+        for rule in get_rules()
+    ],
+)
+def test_formatter(query):
+    assert format_query(query)


### PR DESCRIPTION
Support `offset` following a range vector.

Prior implementation only supported offsetting a single value, rather than also allowing vectors to be offset.
